### PR TITLE
Fixed 'background.scripts' requires manifest version of 2 or lower. this is in one of the extension self developed

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,7 @@
   "version": "2.04",
   "description": "To prevent malpractice, identifies and blocks third-party browser extensions during tests on the iamneo portal.",
   "background": {
-    "service_worker": "background.js",
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyXKMSllCpa1zHLw0m7CbO1iAsi0iwQ5Ij45LbZsuvVnmmL0ahjrv+Rfbks1gZ2rE3nqJCvbyT9VUNMGlW9a09BTlRzrm9RhqaAdN6Mg4Y1fEdwQ6fB/UZG5eGEHKUmilxZrkfgfqVwPauLyIYBxTTyIJcYBQvg4mY1WutMpliP2Xbyva2f+t8iiXDer1lvqprNSbFv15bkwz6G5TJxTmvfK/yWKZUqPuI14WPyeo4KO5OA6+5aXONWw6S62n0D8LbadlkQMJM/Tn24tKAjSST0WpIViOn/rNOd/p1lTlrtXD9NkF3jDLblo+H0UwuItl+qhZd2why9tuejHGKWnS/wIDAQAB",
 


### PR DESCRIPTION
It was giving a error before ->'background.scripts' requires manifest version of 2 or lower. this was due to because in Chrome extension Manifest V3, the "background.scripts" property is no longer supported.